### PR TITLE
Bug fix: Lobby timeout & KartController Server double input

### DIFF
--- a/Assets/_Project/Scripts/KartController.cs
+++ b/Assets/_Project/Scripts/KartController.cs
@@ -252,7 +252,6 @@ namespace Kart {
                         rotation = transform.rotation,
                         velocity = rb.velocity,
                         angularVelocity = rb.angularVelocity,
-                        ping = ping
                     };
                     serverStateBuffer.Add(statePayload, bufferIndex);
                     SendToClientRpc(statePayload);

--- a/Assets/_Project/Scripts/KartController.cs
+++ b/Assets/_Project/Scripts/KartController.cs
@@ -241,6 +241,23 @@ namespace Kart {
                 inputPayload = serverInputQueue.Dequeue();
                 
                 bufferIndex = inputPayload.tick % k_bufferSize;
+
+                if (IsHost) //If we dont check if its host then we will have double input from host. I mean host will move twice faster then he should
+                {
+                    StatePayload statePayload = new StatePayload()
+                    {
+                        tick = inputPayload.tick,
+                        networkObjectId = NetworkObjectId,
+                        position = transform.position,
+                        rotation = transform.rotation,
+                        velocity = rb.velocity,
+                        angularVelocity = rb.angularVelocity,
+                        ping = ping
+                    };
+                    serverStateBuffer.Add(statePayload, bufferIndex);
+                    SendToClientRpc(statePayload);
+                    continue;
+                }
                 
                 StatePayload statePayload = ProcessMovement(inputPayload);
                 serverStateBuffer.Add(statePayload, bufferIndex);

--- a/Assets/_Project/Scripts/Lobby/Multiplayer.cs
+++ b/Assets/_Project/Scripts/Lobby/Multiplayer.cs
@@ -60,6 +60,12 @@ namespace Kart {
             };
         }
 
+        private void Update()
+        {
+            heartbeatTimer.Tick(Time.deltaTime); //If we dont add these lines lobby will not be visible in 30s(by default)
+            pollForUpdatesTimer.Tick(Time.deltaTime);
+        }
+
         async Task Authenticate() {
             await Authenticate("Player" + Random.Range(0, 1000));
         }


### PR DESCRIPTION
In Multiplayer class we have lobby/relay system. But if we dont tick timer in update lobby will not be visible in 30s(default by unity). We can check lobby visibility by this code
        private void Update()
        {
            heartbeatTimer.Tick(Time.deltaTime);
            pollForUpdatesTimer.Tick(Time.deltaTime);
            if (Input.GetKeyDown(KeyCode.Q))
            {
                StartCoroutine(ListAllLobbiesCoroutine());
            }
        }

        private IEnumerator ListAllLobbiesCoroutine()
        {
            var task = ListAllLobbies();
            yield return new WaitUntil(() => task.IsCompleted);
            
            if (task.Exception != null)
            {
                Debug.LogError(task.Exception);
            }
        }
        
         async Task ListAllLobbies()
        {
            try
            {
                QueryLobbiesOptions options = new QueryLobbiesOptions();
                QueryResponse response = await LobbyService.Instance.QueryLobbiesAsync(options);

                foreach (Lobby lobby in response.Results)
                {
                    Debug.Log($"Lobby: {lobby.Name}, ID: {lobby.Id}, Players: {lobby.Players.Count}/{lobby.MaxPlayers}");
                }
            }
            catch (LobbyServiceException e)
            {
                Debug.LogError("Failed to list lobbies: " + e.Message);
            }
        }
In class KartController we handle Clients input by Server. Everything is fine if you are client BUT if you are server and in the same time Client then you will simulate your movement twice. You will gain speed twice faster. Host should only send its current data instead of clients data for himself. After these fixes everything works fine.